### PR TITLE
43 add containerclasses option for header

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup node ${{ matrix.node }}
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ matrix.node }}
       - name: Install dependencies
@@ -48,7 +48,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
       - name: Install dependencies
@@ -74,7 +74,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup node with public npmjs.com registry
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/security_npm_dependency.yml
+++ b/.github/workflows/security_npm_dependency.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   security-npm-dependency-check:
     name: Project security npm dependency check
-    uses: ministryofjustice/hmpps-github-actions/.github/workflows/security_npm_dependency.yml@5156d7f46810b00163ce8e6a180346f00d8cc055 # v2.16.1
+    uses: ministryofjustice/hmpps-github-actions/.github/workflows/security_npm_dependency.yml@3d0db04bde36486d182b5c7d4a3bb8794bdeb2c6 # v2.18.0
     with:
       channel_id: ${{ vars.SECURITY_ALERTS_SLACK_CHANNEL_ID || 'NO_SLACK' }}
     secrets: inherit

--- a/.gitleaks/.gitleaksignore
+++ b/.gitleaks/.gitleaksignore
@@ -1,1 +1,5 @@
 # The Fingerprint of false positive alerts can be added here to be excluded from future scans.
+
+# dummy user tokens for tests:
+src/componentsService.test.ts:generic-api-key:84
+src/componentsService.test.ts:generic-api-key:65

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ministryofjustice/hmpps-probation-frontend-components",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ministryofjustice/hmpps-probation-frontend-components",
-      "version": "1.0.4",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "@types/node": "22.20.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ministryofjustice/hmpps-probation-frontend-components",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ministryofjustice/hmpps-probation-frontend-components",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "MIT",
       "dependencies": {
         "@types/node": "22.20.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1836,9 +1836,9 @@
       }
     },
     "node_modules/@types/supertest": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@types/supertest/-/supertest-7.2.0.tgz",
-      "integrity": "sha512-uh2Lv57xvggst6lCqNdFAmDSvoMG7M/HDtX4iUCquxQ5EGPtaPM5PL5Hmi7LCvOG8db7YaCPNJEeoI8s/WzIQw==",
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/@types/supertest/-/supertest-7.2.1.tgz",
+      "integrity": "sha512-4CbBvoYVLHL7+yhbYrZET0vsvuyXTC05aRe7dNQkwMzm56auceoy6Yu3K50uZmwfHna1os3CMSgM/3QVkUtPTw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1864,17 +1864,17 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.62.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.62.1.tgz",
-      "integrity": "sha512-4EQM77WgVNxj7OkL/5b/D/xZsw00G577+UriYTC7JF5opcF3T2AuoeY7ueLaZgSVjSgCS6yOAJB5bRGLPSJUzA==",
+      "version": "8.64.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.64.0.tgz",
+      "integrity": "sha512-CGvQPBxN3wZLu6Rz2kFUpZeoCm78xUic92ck39KPePkO1NPOwjCqdQnm5Q87tpWw9vcBvW8XLrDXjH9PWYtJ3Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.62.1",
-        "@typescript-eslint/type-utils": "8.62.1",
-        "@typescript-eslint/utils": "8.62.1",
-        "@typescript-eslint/visitor-keys": "8.62.1",
+        "@typescript-eslint/scope-manager": "8.64.0",
+        "@typescript-eslint/type-utils": "8.64.0",
+        "@typescript-eslint/utils": "8.64.0",
+        "@typescript-eslint/visitor-keys": "8.64.0",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -1887,7 +1887,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.62.1",
+        "@typescript-eslint/parser": "^8.64.0",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
@@ -1903,16 +1903,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.62.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.62.1.tgz",
-      "integrity": "sha512-sPhE4iHuJDSvoAiec+Ro8JyXw8f0ql13HFR82P99nCm9GwTEKG0KYLvDe6REk8BCXuit6vJAv/Yxg5ABaNS2rA==",
+      "version": "8.64.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.64.0.tgz",
+      "integrity": "sha512-KA0OshtlcCCXmbfqyZkM5pV3/WNraJf7DkJRLpyrmwPtud57H5BDX7C3k0LPSPxpprfRL+cJDGabF10mvNCoCw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.62.1",
-        "@typescript-eslint/types": "8.62.1",
-        "@typescript-eslint/typescript-estree": "8.62.1",
-        "@typescript-eslint/visitor-keys": "8.62.1",
+        "@typescript-eslint/scope-manager": "8.64.0",
+        "@typescript-eslint/types": "8.64.0",
+        "@typescript-eslint/typescript-estree": "8.64.0",
+        "@typescript-eslint/visitor-keys": "8.64.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -1928,14 +1928,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.62.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.62.1.tgz",
-      "integrity": "sha512-yQ3RgY5RkSBpsNS1Bx/JQEcA24FOSdfGktoyprAr5u18390UQdtVcfnEv4nIrIshNnavlVyZBKxQwT1fIAE6cg==",
+      "version": "8.64.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.64.0.tgz",
+      "integrity": "sha512-tk4WpOJ6IEbGrVHaNmM0YRrwAD3exZlIK3iadQNAxh4YKk6jvUQ4ecq18n+v7+meh+cJ3j+D8nbk8sRKhlwLQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.62.1",
-        "@typescript-eslint/types": "^8.62.1",
+        "@typescript-eslint/tsconfig-utils": "^8.64.0",
+        "@typescript-eslint/types": "^8.64.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -1950,14 +1950,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.62.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.62.1.tgz",
-      "integrity": "sha512-r4d249KbQ1SFdpeStvob8Ih6aPPIzfqllPVOtvhve6ZcpuVcYo5/7zUWckKpHE7StASX4kTKZTLf0WQm/wPkcg==",
+      "version": "8.64.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.64.0.tgz",
+      "integrity": "sha512-CXEaFdYXjSTgKhisNkwCcJwTP8Pl+fmRrEQrri4nm3vU743bALrxzLmq7fHG/7e6a5xO0lDYeURpZmBuhHk54w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.62.1",
-        "@typescript-eslint/visitor-keys": "8.62.1"
+        "@typescript-eslint/types": "8.64.0",
+        "@typescript-eslint/visitor-keys": "8.64.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1968,9 +1968,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.62.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.62.1.tgz",
-      "integrity": "sha512-xadytJqX9vJVQ2fdQjkcIVigwaOJNWkpjdLt6cEQ+xPnrI1fkp+/jZE/I97k9KUjqtpd25i0HeyZf3T6dutv2g==",
+      "version": "8.64.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.64.0.tgz",
+      "integrity": "sha512-2yo8rRNKuzbVWQp5kslhANqZ2uDAeROQHBRZNPu8JDsHmeFNj/XJJhX/FhNUWmkHHvoNsKa6+tHJiig87EzsQw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1985,15 +1985,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.62.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.62.1.tgz",
-      "integrity": "sha512-aXM5xlqXiTxPibXB93cLAURfT3rlizf7uMXISCXy66Isr/9hISJx3yDsKl0L7lKa51b8JpFuNKby0/O0pEm9jg==",
+      "version": "8.64.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.64.0.tgz",
+      "integrity": "sha512-XWG4Fmmv/6SvyS9nH8jWrKs6terwJvE8cyRt1CzYYqzp9OrPhCT4cMc/f7C6RZCwG+qMmiffJS1/qJP8G1URtg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.62.1",
-        "@typescript-eslint/typescript-estree": "8.62.1",
-        "@typescript-eslint/utils": "8.62.1",
+        "@typescript-eslint/types": "8.64.0",
+        "@typescript-eslint/typescript-estree": "8.64.0",
+        "@typescript-eslint/utils": "8.64.0",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -2010,9 +2010,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.62.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.62.1.tgz",
-      "integrity": "sha512-ooCzJFaf+Hg+uG6fA3NRFGuFjlfNlDhBthbv4ZPU/0elCAFUfnyXUvf/WOpHz/jYwSmvU2GkR2LtyUfy1AxZ1Q==",
+      "version": "8.64.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.64.0.tgz",
+      "integrity": "sha512-qjhfuTfLXjA4IOzXvz0rTjT01BqEiIgPoUeMwiEjnaHKJMTNo8rH5pYW1a2L/0Dnux2fPC85AeyJoWaGa8WxTA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2024,16 +2024,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.62.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.62.1.tgz",
-      "integrity": "sha512-xMcW9oP9u7fAMXYs9A65CVmtLQe2r//oXINHfi8HV+oiqhih17sbLdhXr4540YWlgpDKQdY854OL5ZrdCiQsAA==",
+      "version": "8.64.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.64.0.tgz",
+      "integrity": "sha512-Pztpsn1aCE1oWDvDEfUk31nngvvF7vUB5SwHFEaZIFpvw7WJtqUHHL4plBZDA9HfWJJjL13BdG0YrJInTUvoVA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.62.1",
-        "@typescript-eslint/tsconfig-utils": "8.62.1",
-        "@typescript-eslint/types": "8.62.1",
-        "@typescript-eslint/visitor-keys": "8.62.1",
+        "@typescript-eslint/project-service": "8.64.0",
+        "@typescript-eslint/tsconfig-utils": "8.64.0",
+        "@typescript-eslint/types": "8.64.0",
+        "@typescript-eslint/visitor-keys": "8.64.0",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -2091,16 +2091,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.62.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.62.1.tgz",
-      "integrity": "sha512-sHtbPfuKNZCG+ih8SyjjucqRntSVmp8XgL5u6o9mAhiSn8ds5o/M/XdM0abweme2Tln3szOstOrZ9OXitvPh0g==",
+      "version": "8.64.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.64.0.tgz",
+      "integrity": "sha512-aJUGVB3+U0htrrCjoA8qukw8cm8fNCGAxK/tVoS70k8aeb7DETKeFozRiVFIwEeN9WJLsjaP3ph8I60tY2XZoQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.62.1",
-        "@typescript-eslint/types": "8.62.1",
-        "@typescript-eslint/typescript-estree": "8.62.1"
+        "@typescript-eslint/scope-manager": "8.64.0",
+        "@typescript-eslint/types": "8.64.0",
+        "@typescript-eslint/typescript-estree": "8.64.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2115,13 +2115,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.62.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.62.1.tgz",
-      "integrity": "sha512-4g3BLxfdTMy8iZG0MaBkadnlRrCJ74cQiFbyEVMrkwIoqdyaXXQM22cotDvrl4x28wgIZ9rEJRoM+mmhSJpJ1g==",
+      "version": "8.64.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.64.0.tgz",
+      "integrity": "sha512-mrtuL8Nsn6gi2H4mo5KMTp823M+3Q19Ew/i+Zlikq20tIMm99C3Ez0dCmkWWnxut20esQvTg8aUSEhMcAOXhEw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.62.1",
+        "@typescript-eslint/types": "8.64.0",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -5080,9 +5080,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-6.3.0.tgz",
-      "integrity": "sha512-cXIQxm5PHCsbic47GXZrVBZhAeeshTLRL6ZBKilLsR6rMCjJuWb7Fruq0VUNMBJFlJk/srsRj/q8d5bM9cgKoA==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-6.4.0.tgz",
+      "integrity": "sha512-jU3oaVFXqK1yDVIdZs1YZ6JD7YDB4PFUHF3rFMWJye9ArImp42F9wCsFzzB1+udjuzGCryJGcHHbBQ5HY+8rqQ==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ministryofjustice/hmpps-probation-frontend-components",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "A package to allow the inclusion of connect pds micro frontend components within pds applications",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ministryofjustice/hmpps-probation-frontend-components",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "description": "A package to allow the inclusion of connect pds micro frontend components within pds applications",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/assets/pdsComponents/header.njk
+++ b/src/assets/pdsComponents/header.njk
@@ -1,5 +1,5 @@
 {% from "govuk/components/tag/macro.njk" import govukTag %}
-<header class="probation-common-fallback-header govuk-!-display-none-print" role="banner">
+<header class="probation-common-fallback-header govuk-!-display-none-print {% if classes %}{{ classes }}{% endif %}" role="banner">
   <div class="probation-common-fallback-header__container">
     <div class="probation-common-fallback-header__title">
       <a class="probation-common-fallback-header__link probation-common-fallback-header__title__organisation-name" href="#">

--- a/src/componentsService.function.test.ts
+++ b/src/componentsService.function.test.ts
@@ -76,11 +76,7 @@ describe('getFrontendComponents', () => {
   describe('fallbacks', () => {
     describe('when probation user', () => {
       it('should provide a fallback header', async () => {
-        componentsApi
-          .get('/api/components?component=header&component=footer')
-          .reply(500)
-          .get('/api/components?component=header&component=footer')
-          .reply(500)
+        componentsApi.get('/api/components?component=header&component=footer').reply(500)
 
         return request(setupApp())
           .get('/')
@@ -99,11 +95,7 @@ describe('getFrontendComponents', () => {
       })
 
       it('should provide a fallback footer', async () => {
-        componentsApi
-          .get('/api/components?component=header&component=footer')
-          .reply(500)
-          .get('/api/components?component=header&component=footer')
-          .reply(500)
+        componentsApi.get('/api/components?component=header&component=footer').reply(500)
 
         return request(setupApp())
           .get('/')

--- a/src/componentsService.function.test.ts
+++ b/src/componentsService.function.test.ts
@@ -1,0 +1,137 @@
+import express from 'express'
+import nunjucks from 'nunjucks'
+import request from 'supertest'
+import nock from 'nock'
+import * as cheerio from 'cheerio'
+import getFrontendComponents from './componentsService'
+import config from './config'
+import { HmppsUser, ProbationUser } from './types/HmppsUser'
+
+const probationUser = { token: 'token', authSource: 'delius', displayName: 'Edwin Shannon' } as ProbationUser
+const apiResponse = {
+  header: { html: 'header', css: ['header.css'], javascript: ['header.js'] },
+  footer: { html: 'footer', css: ['footer.css'], javascript: ['footer.js'] },
+}
+
+function setupApp(
+  {
+    user,
+    useFallbacksByDefault,
+  }: {
+    user?: HmppsUser
+    useFallbacksByDefault?: boolean
+  } = { user: probationUser, useFallbacksByDefault: false },
+): express.Application {
+  const app = express()
+  app.use((req, res, next) => {
+    res.locals.user = user
+    next()
+  })
+
+  app.set('view engine', 'njk')
+  nunjucks.configure(
+    ['src/assets', 'node_modules/govuk-frontend/dist/', 'node_modules/govuk-frontend/dist/components/'],
+    { autoescape: true, express: app },
+  )
+
+  app.use(
+    getFrontendComponents({
+      pdsUrl: 'http://pdsUrl',
+      useFallbacksByDefault,
+    }),
+  )
+
+  app.get('/', (_req, res) => res.send({ feComponents: res.locals.feComponents }))
+
+  return app
+}
+
+let componentsApi: nock.Scope
+
+beforeEach(() => {
+  componentsApi = nock(config.apis.feComponents.url)
+})
+
+afterEach(() => {
+  jest.resetAllMocks()
+})
+
+describe('getFrontendComponents', () => {
+  it('should call fe components api and attach header and footer html with all css and js combined', async () => {
+    componentsApi.get('/api/components?component=header&component=footer').reply(200, apiResponse)
+
+    return request(setupApp())
+      .get('/')
+      .expect('Content-Type', /json/)
+      .expect(200, {
+        feComponents: {
+          header: 'header',
+          footer: 'footer',
+          cssIncludes: ['header.css', 'footer.css'],
+          jsIncludes: ['header.js', 'footer.js'],
+        },
+      })
+  })
+
+  describe('fallbacks', () => {
+    describe('when probation user', () => {
+      it('should provide a fallback header', async () => {
+        componentsApi
+          .get('/api/components?component=header&component=footer')
+          .reply(500)
+          .get('/api/components?component=header&component=footer')
+          .reply(500)
+
+        return request(setupApp())
+          .get('/')
+          .expect('Content-Type', /json/)
+          .expect(200)
+          .expect(res => {
+            const $header = cheerio.load(res.body.feComponents.header)
+
+            expect($header('[data-qa="header-user-name"]').text()).toContain('E. Shannon')
+            expect($header('a[href="http://pdsUrl"]').text()).toContain('Probation Digital Services')
+            expect($header('a[href="/sign-out"]').text()).toContain('Sign out')
+
+            expect(res.body.feComponents.cssIncludes).toEqual([])
+            expect(res.body.feComponents.jsIncludes).toEqual([])
+          })
+      })
+
+      it('should provide a fallback footer', async () => {
+        componentsApi
+          .get('/api/components?component=header&component=footer')
+          .reply(500)
+          .get('/api/components?component=header&component=footer')
+          .reply(500)
+
+        return request(setupApp())
+          .get('/')
+          .expect('Content-Type', /json/)
+          .expect(200)
+          .expect(res => {
+            expect(normaliseHtml(res.body.feComponents.footer)).toEqual(
+              normaliseHtml(
+                '<footer class="probation-common-fallback-footer govuk-!-display-none-print" role="contentinfo">' +
+                  '<div class="govuk-width-container">' +
+                  '<div class="govuk-grid-row">' +
+                  '<div class="govuk-grid-column-full">' +
+                  '</div>' +
+                  '</div>' +
+                  '</div>' +
+                  '</footer>',
+              ),
+            )
+
+            expect(res.body.feComponents.cssIncludes).toEqual([])
+            expect(res.body.feComponents.jsIncludes).toEqual([])
+          })
+      })
+    })
+  })
+})
+
+const normaliseHtml = html =>
+  html
+    .replace(/>\s+</g, '><') // remove inter-tag whitespace
+    .trim()

--- a/src/componentsService.function.test.ts
+++ b/src/componentsService.function.test.ts
@@ -6,6 +6,7 @@ import * as cheerio from 'cheerio'
 import getFrontendComponents from './componentsService'
 import config from './config'
 import { HmppsUser, ProbationUser } from './types/HmppsUser'
+import { fakeLogger } from '../test/helpers/loggerStub'
 
 const probationUser = { token: 'token', authSource: 'delius', displayName: 'Edwin Shannon' } as ProbationUser
 const apiResponse = {
@@ -38,6 +39,7 @@ function setupApp(
     getFrontendComponents({
       pdsUrl: 'http://pdsUrl',
       useFallbacksByDefault,
+      logger: fakeLogger(),
     }),
   )
 

--- a/src/componentsService.function.test.ts
+++ b/src/componentsService.function.test.ts
@@ -23,7 +23,7 @@ function setupApp(
   } = { user: probationUser, useFallbacksByDefault: false },
 ): express.Application {
   const app = express()
-  app.use((req, res, next) => {
+  app.use((_req, res, next) => {
     res.locals.user = user
     next()
   })
@@ -123,7 +123,7 @@ describe('getFrontendComponents', () => {
   })
 })
 
-const normaliseHtml = html =>
+const normaliseHtml = (html: string) =>
   html
     .replace(/>\s+</g, '><') // remove inter-tag whitespace
     .trim()

--- a/src/componentsService.test.ts
+++ b/src/componentsService.test.ts
@@ -49,12 +49,12 @@ describe('getFrontendComponents', () => {
   const stubUpdateCsp = () => jest.spyOn(UpdateCspModule, 'default').mockImplementation(jest.fn())
 
   describe('when API client successfully fetches the content', () => {
-    it('request the compnents content from the API clients', async () => {
+    it('request the components content from the API clients', async () => {
       // Given
       const middleware = getFrontendComponents({ pdsUrl: '' })
       stubUpdateCsp()
       const req = {} as Request
-      const res = createResponseObject('hgjgjhgjhg')
+      const res = createResponseObject('phUw9cruyosubane')
       stubGetComponent(apiResponse)
 
       // When
@@ -62,18 +62,18 @@ describe('getFrontendComponents', () => {
 
       // Then
       expect(ComponentApiClientModule.getComponents).toHaveBeenCalledWith({
-        userToken: 'hgjgjhgjhg',
+        userToken: 'phUw9cruyosubane',
         timeoutOptions: { response: 2500, deadline: 2500 },
         log: console,
       })
     })
 
-    it('request the compnents content with the added classes when provided', async () => {
+    it('request the components content with the added classes when provided', async () => {
       // Given
       const middleware = getFrontendComponents({ pdsUrl: '', classes: 'my-classes' })
       stubUpdateCsp()
       const req = {} as Request
-      const res = createResponseObject('hgjgjhgjhg')
+      const res = createResponseObject('phUw9cruyosubane')
       stubGetComponent(apiResponse)
 
       // When
@@ -81,7 +81,7 @@ describe('getFrontendComponents', () => {
 
       // Then
       expect(ComponentApiClientModule.getComponents).toHaveBeenCalledWith({
-        userToken: 'hgjgjhgjhg',
+        userToken: 'phUw9cruyosubane',
         timeoutOptions: { response: 2500, deadline: 2500 },
         log: console,
         classes: 'my-classes',
@@ -93,7 +93,7 @@ describe('getFrontendComponents', () => {
       const middleware = getFrontendComponents({ pdsUrl: '', classes: 'my-classes' })
       stubUpdateCsp()
       const req = {} as Request
-      const res = createResponseObject('hgjgjhgjhg')
+      const res = createResponseObject('phUw9cruyosubane')
       stubGetComponent(apiResponse)
 
       // When
@@ -111,7 +111,7 @@ describe('getFrontendComponents', () => {
       const middleware = getFrontendComponents({ pdsUrl: '' })
       stubUpdateCsp()
       const req = {} as Request
-      const res = createResponseObject('hgjgjhgjhg')
+      const res = createResponseObject('phUw9cruyosubane')
       stubGetComponent(apiResponse)
 
       // When
@@ -130,7 +130,7 @@ describe('getFrontendComponents', () => {
       // Given
       const middleware = getFrontendComponents({ pdsUrl: '', useFallbacksByDefault: true })
       const req = {} as Request
-      const res = createResponseObject('hgjgjhgjhg')
+      const res = createResponseObject('phUw9cruyosubane')
       jest.spyOn(ComponentApiClientModule, 'getComponents')
 
       // When
@@ -144,7 +144,7 @@ describe('getFrontendComponents', () => {
       // Given
       const middleware = getFrontendComponents({ pdsUrl: '', useFallbacksByDefault: true })
       const req = {} as Request
-      const res = createResponseObject('hgjgjhgjhg')
+      const res = createResponseObject('phUw9cruyosubane')
       jest.spyOn(ComponentApiClientModule, 'getComponents')
 
       // When
@@ -155,11 +155,28 @@ describe('getFrontendComponents', () => {
       expect(res.locals.feComponents.header).toContain('probation-common-fallback-header__link')
     })
 
+    it('returns the expected footer component when classes are added to the header', async () => {
+      // Given
+      const middleware = getFrontendComponents({ pdsUrl: '', useFallbacksByDefault: true, classes: 'my-classes' })
+      const req = {} as Request
+      const res = createResponseObject('phUw9cruyosubane')
+      jest.spyOn(ComponentApiClientModule, 'getComponents')
+
+      // When
+      await middleware(req, res, jest.fn() as NextFunction)
+
+      // Then
+      expect(res.locals.feComponents).toBeDefined()
+      expect(res.locals.feComponents.footer).toContain('probation-common-fallback-footer')
+      expect(res.locals.feComponents.cssIncludes).toHaveLength(0)
+      expect(res.locals.feComponents.jsIncludes).toHaveLength(0)
+    })
+
     it('return the content of the footer fallback component', async () => {
       // Given
       const middleware = getFrontendComponents({ pdsUrl: '', useFallbacksByDefault: true })
       const req = {} as Request
-      const res = createResponseObject('hgjgjhgjhg')
+      const res = createResponseObject('phUw9cruyosubane')
       jest.spyOn(ComponentApiClientModule, 'getComponents')
 
       // When
@@ -226,7 +243,7 @@ describe('getFrontendComponents', () => {
       // Given
       const middleware = getFrontendComponents({ pdsUrl: '' })
       const req = {} as Request
-      const res = createResponseObject('hgjgjhgjhg')
+      const res = createResponseObject('phUw9cruyosubane')
       jest.spyOn(ComponentApiClientModule, 'getComponents').mockRejectedValue('some sort of exception')
 
       // When
@@ -241,7 +258,7 @@ describe('getFrontendComponents', () => {
       // Given
       const middleware = getFrontendComponents({ pdsUrl: '' })
       const req = {} as Request
-      const res = createResponseObject('hgjgjhgjhg')
+      const res = createResponseObject('phUw9cruyosubane')
       jest.spyOn(ComponentApiClientModule, 'getComponents').mockRejectedValue('some sort of exception')
 
       // When

--- a/src/componentsService.test.ts
+++ b/src/componentsService.test.ts
@@ -1,27 +1,14 @@
-import nock from 'nock'
-import * as cheerio from 'cheerio'
 import { Request, Response, NextFunction } from 'express'
 import nunjucks from 'nunjucks'
 import { describe } from 'node:test'
 import getFrontendComponents from './componentsService'
-import config from './config'
-import { HmppsUser, ProbationUser } from './types/HmppsUser'
 import * as UpdateCspModule from './utils/updateCsp'
 import ComponentApiClientModule from './data/componentApi/componentApiClient'
 
-const probationUser = { token: 'token', authSource: 'delius', displayName: 'Edwin Shannon' } as ProbationUser
 const apiResponse = {
   header: { html: 'header', css: ['header.css'], javascript: ['header.js'] },
   footer: { html: 'footer', css: ['footer.css'], javascript: ['footer.js'] },
 }
-
-beforeEach(() => {
-  //
-})
-
-afterEach(() => {
-  jest.resetAllMocks()
-})
 
 nunjucks.configure(
   ['src/assets', 'node_modules/govuk-frontend/dist/', 'node_modules/govuk-frontend/dist/components/'],
@@ -29,6 +16,18 @@ nunjucks.configure(
 )
 
 describe('getFrontendComponents', () => {
+  beforeEach(() => {
+    jest.clearAllMocks() // Clear call histories between tests
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  afterAll(() => {
+    jest.clearAllMocks() // Clear call histories between tests
+  })
+
   function stubGetComponent(response: any) {
     jest.spyOn(ComponentApiClientModule, 'getComponents').mockResolvedValue(response)
   }

--- a/src/componentsService.test.ts
+++ b/src/componentsService.test.ts
@@ -1,49 +1,16 @@
-import express from 'express'
-import nunjucks from 'nunjucks'
-import request from 'supertest'
 import nock from 'nock'
 import * as cheerio from 'cheerio'
+import { Request, Response, NextFunction } from 'express'
+import nunjucks from 'nunjucks'
 import getFrontendComponents from './componentsService'
 import config from './config'
 import { HmppsUser, ProbationUser } from './types/HmppsUser'
+import ComponentApiClientModule from './data/componentApi/componentApiClient'
 
 const probationUser = { token: 'token', authSource: 'delius', displayName: 'Edwin Shannon' } as ProbationUser
 const apiResponse = {
   header: { html: 'header', css: ['header.css'], javascript: ['header.js'] },
   footer: { html: 'footer', css: ['footer.css'], javascript: ['footer.js'] },
-}
-
-function setupApp(
-  {
-    user,
-    useFallbacksByDefault,
-  }: {
-    user?: HmppsUser
-    useFallbacksByDefault?: boolean
-  } = { user: probationUser, useFallbacksByDefault: false },
-): express.Application {
-  const app = express()
-  app.use((req, res, next) => {
-    res.locals.user = user
-    next()
-  })
-
-  app.set('view engine', 'njk')
-  nunjucks.configure(
-    ['src/assets', 'node_modules/govuk-frontend/dist/', 'node_modules/govuk-frontend/dist/components/'],
-    { autoescape: true, express: app },
-  )
-
-  app.use(
-    getFrontendComponents({
-      pdsUrl: 'http://pdsUrl',
-      useFallbacksByDefault,
-    }),
-  )
-
-  app.get('/', (_req, res) => res.send({ feComponents: res.locals.feComponents }))
-
-  return app
 }
 
 let componentsApi: nock.Scope
@@ -56,172 +23,26 @@ afterEach(() => {
   jest.resetAllMocks()
 })
 
+nunjucks.configure(
+  ['src/assets', 'node_modules/govuk-frontend/dist/', 'node_modules/govuk-frontend/dist/components/'],
+  { autoescape: true },
+)
+
 describe('getFrontendComponents', () => {
-  it('should call fe components api and attach header and footer html with all css and js combined', async () => {
-    componentsApi.get('/api/components?component=header&component=footer').reply(200, apiResponse)
+  it('request the compnents content from the API clients', async () => {
+    // Given
+    const middleware = getFrontendComponents({ pdsUrl: '' })
+    const req = {} as Request
+    const res = {
+      locals: {
+        user: { token: 'hgjgjhgjhg' },
+      },
+    } as any as Response
+    jest.spyOn(ComponentApiClientModule, 'getComponents').mockResolvedValue({})
 
-    return request(setupApp())
-      .get('/')
-      .expect('Content-Type', /json/)
-      .expect(200, {
-        feComponents: {
-          header: 'header',
-          footer: 'footer',
-          cssIncludes: ['header.css', 'footer.css'],
-          jsIncludes: ['header.js', 'footer.js'],
-        },
-      })
-  })
+    // When
+    await middleware(req, res, jest.fn() as NextFunction)
 
-  describe('fallbacks', () => {
-    describe('when probation user', () => {
-      it('should provide a fallback header', async () => {
-        componentsApi
-          .get('/api/components?component=header&component=footer')
-          .reply(500)
-          .get('/api/components?component=header&component=footer')
-          .reply(500)
-
-        return request(setupApp())
-          .get('/')
-          .expect('Content-Type', /json/)
-          .expect(200)
-          .expect(res => {
-            const $header = cheerio.load(res.body.feComponents.header)
-
-            expect($header('[data-qa="header-user-name"]').text()).toContain('E. Shannon')
-            expect($header('a[href="http://pdsUrl"]').text()).toContain('Probation Digital Services')
-            expect($header('a[href="/sign-out"]').text()).toContain('Sign out')
-
-            expect(res.body.feComponents.cssIncludes).toEqual([])
-            expect(res.body.feComponents.jsIncludes).toEqual([])
-          })
-      })
-
-      it('should provide a fallback footer', async () => {
-        componentsApi
-          .get('/api/components?component=header&component=footer')
-          .reply(500)
-          .get('/api/components?component=header&component=footer')
-          .reply(500)
-
-        return request(setupApp())
-          .get('/')
-          .expect('Content-Type', /json/)
-          .expect(200)
-          .expect(res => {
-            expect(normaliseHtml(res.body.feComponents.footer)).toEqual(
-              normaliseHtml(
-                '<footer class="probation-common-fallback-footer govuk-!-display-none-print" role="contentinfo">' +
-                  '<div class="govuk-width-container">' +
-                  '<div class="govuk-grid-row">' +
-                  '<div class="govuk-grid-column-full">' +
-                  '</div>' +
-                  '</div>' +
-                  '</div>' +
-                  '</footer>',
-              ),
-            )
-
-            expect(res.body.feComponents.cssIncludes).toEqual([])
-            expect(res.body.feComponents.jsIncludes).toEqual([])
-          })
-      })
-    })
-
-    describe('when no user', () => {
-      it('should provide a fallback header', async () => {
-        return request(setupApp({ user: undefined }))
-          .get('/')
-          .expect('Content-Type', /json/)
-          .expect(200)
-          .expect(res => {
-            const $header = cheerio.load(res.body.feComponents.header)
-
-            expect($header('[data-qa="header-user-name"]').length).toEqual(0)
-            expect($header('a[href="http://pdsUrl"]').text()).toContain('Probation Digital Services')
-            expect($header('a[href="/sign-out"]').length).toEqual(0)
-
-            expect(res.body.feComponents.cssIncludes).toEqual([])
-            expect(res.body.feComponents.jsIncludes).toEqual([])
-          })
-      })
-
-      it('should provide a fallback footer', async () => {
-        return request(setupApp({ user: undefined }))
-          .get('/')
-          .expect('Content-Type', /json/)
-          .expect(200)
-          .expect(res => {
-            expect(normaliseHtml(res.body.feComponents.footer)).toEqual(
-              normaliseHtml(
-                '<footer class="probation-common-fallback-footer govuk-!-display-none-print" role="contentinfo">' +
-                  '<div class="govuk-width-container">' +
-                  '<div class="govuk-grid-row">' +
-                  '<div class="govuk-grid-column-full">' +
-                  '</div>' +
-                  '</div>' +
-                  '</div>' +
-                  '</footer>',
-              ),
-            )
-
-            expect(res.body.feComponents.cssIncludes).toEqual([])
-            expect(res.body.feComponents.jsIncludes).toEqual([])
-          })
-      })
-    })
-
-    describe('when configured to only use fallbacks', () => {
-      it('should provide a fallback header', async () => {
-        componentsApi.get('/api/components?component=header&component=footer').reply(200, apiResponse)
-
-        return request(setupApp({ user: probationUser, useFallbacksByDefault: true }))
-          .get('/')
-          .expect('Content-Type', /json/)
-          .expect(200)
-          .expect(res => {
-            const $header = cheerio.load(res.body.feComponents.header)
-
-            expect($header('[data-qa="header-user-name"]').text()).toContain('E. Shannon')
-            expect($header('a[href="http://pdsUrl"]').text()).toContain('Probation Digital Services')
-            expect($header('a[href="/sign-out"]').text()).toContain('Sign out')
-
-            expect(res.body.feComponents.cssIncludes).toEqual([])
-            expect(res.body.feComponents.jsIncludes).toEqual([])
-          })
-      })
-
-      it('should provide a fallback footer', async () => {
-        componentsApi.get('/api/components?component=header&component=footer').reply(200, apiResponse)
-
-        return request(setupApp({ user: probationUser, useFallbacksByDefault: true }))
-          .get('/')
-          .expect('Content-Type', /json/)
-          .expect(200)
-          .expect(res => {
-            expect(normaliseHtml(res.body.feComponents.footer)).toEqual(
-              normaliseHtml(
-                '<footer class="probation-common-fallback-footer govuk-!-display-none-print" role="contentinfo">' +
-                  '<div class="govuk-width-container">' +
-                  '<div class="govuk-grid-row">' +
-                  '<div class="govuk-grid-column-full">' +
-                  '</div>' +
-                  '</div>' +
-                  '</div>' +
-                  '</footer>',
-              ),
-            )
-
-            expect(res.body.feComponents.cssIncludes).toEqual([])
-            expect(res.body.feComponents.jsIncludes).toEqual([])
-          })
-      })
-    })
+    // Then
   })
 })
-
-const normaliseHtml = html =>
-  html
-    .replace(/>\s+</g, '><') // remove inter-tag whitespace
-    .trim()

--- a/src/componentsService.test.ts
+++ b/src/componentsService.test.ts
@@ -2,9 +2,11 @@ import nock from 'nock'
 import * as cheerio from 'cheerio'
 import { Request, Response, NextFunction } from 'express'
 import nunjucks from 'nunjucks'
+import { describe } from 'node:test'
 import getFrontendComponents from './componentsService'
 import config from './config'
 import { HmppsUser, ProbationUser } from './types/HmppsUser'
+import * as UpdateCspModule from './utils/updateCsp'
 import ComponentApiClientModule from './data/componentApi/componentApiClient'
 
 const probationUser = { token: 'token', authSource: 'delius', displayName: 'Edwin Shannon' } as ProbationUser
@@ -13,10 +15,8 @@ const apiResponse = {
   footer: { html: 'footer', css: ['footer.css'], javascript: ['footer.js'] },
 }
 
-let componentsApi: nock.Scope
-
 beforeEach(() => {
-  componentsApi = nock(config.apis.feComponents.url)
+  //
 })
 
 afterEach(() => {
@@ -29,20 +29,230 @@ nunjucks.configure(
 )
 
 describe('getFrontendComponents', () => {
-  it('request the compnents content from the API clients', async () => {
-    // Given
-    const middleware = getFrontendComponents({ pdsUrl: '' })
-    const req = {} as Request
-    const res = {
+  function stubGetComponent(response: any) {
+    jest.spyOn(ComponentApiClientModule, 'getComponents').mockResolvedValue(response)
+  }
+
+  function createResponseObject(token: string) {
+    return {
       locals: {
-        user: { token: 'hgjgjhgjhg' },
+        user: { token },
       },
     } as any as Response
-    jest.spyOn(ComponentApiClientModule, 'getComponents').mockResolvedValue({})
+  }
 
-    // When
-    await middleware(req, res, jest.fn() as NextFunction)
+  function createResponseObjectWithNoUser() {
+    return {
+      locals: {},
+    } as any as Response
+  }
 
-    // Then
+  const stubUpdateCsp = () => jest.spyOn(UpdateCspModule, 'default').mockImplementation(jest.fn())
+
+  describe('when API client successfully fetches the content', () => {
+    it('request the compnents content from the API clients', async () => {
+      // Given
+      const middleware = getFrontendComponents({ pdsUrl: '' })
+      stubUpdateCsp()
+      const req = {} as Request
+      const res = createResponseObject('hgjgjhgjhg')
+      stubGetComponent(apiResponse)
+
+      // When
+      await middleware(req, res, jest.fn() as NextFunction)
+
+      // Then
+      expect(ComponentApiClientModule.getComponents).toHaveBeenCalledWith({
+        userToken: 'hgjgjhgjhg',
+        timeoutOptions: { response: 2500, deadline: 2500 },
+        log: console,
+      })
+    })
+
+    it('request the compnents content with the added classes when provided', async () => {
+      // Given
+      const middleware = getFrontendComponents({ pdsUrl: '', classes: 'my-classes' })
+      stubUpdateCsp()
+      const req = {} as Request
+      const res = createResponseObject('hgjgjhgjhg')
+      stubGetComponent(apiResponse)
+
+      // When
+      await middleware(req, res, jest.fn() as NextFunction)
+
+      // Then
+      expect(ComponentApiClientModule.getComponents).toHaveBeenCalledWith({
+        userToken: 'hgjgjhgjhg',
+        timeoutOptions: { response: 2500, deadline: 2500 },
+        log: console,
+        classes: 'my-classes',
+      })
+    })
+
+    it('sets the header component content from the API response in the response object', async () => {
+      // Given
+      const middleware = getFrontendComponents({ pdsUrl: '', classes: 'my-classes' })
+      stubUpdateCsp()
+      const req = {} as Request
+      const res = createResponseObject('hgjgjhgjhg')
+      stubGetComponent(apiResponse)
+
+      // When
+      await middleware(req, res, jest.fn() as NextFunction)
+
+      // Then
+      expect(res.locals.feComponents).toBeDefined()
+      expect(res.locals.feComponents.header).toEqual('header')
+      expect(res.locals.feComponents.cssIncludes[0]).toEqual('header.css')
+      expect(res.locals.feComponents.jsIncludes[0]).toEqual('header.js')
+    })
+
+    it('sets the footer component content from the API response in the response object', async () => {
+      // Given
+      const middleware = getFrontendComponents({ pdsUrl: '' })
+      stubUpdateCsp()
+      const req = {} as Request
+      const res = createResponseObject('hgjgjhgjhg')
+      stubGetComponent(apiResponse)
+
+      // When
+      await middleware(req, res, jest.fn() as NextFunction)
+
+      // Then
+      expect(res.locals.feComponents).toBeDefined()
+      expect(res.locals.feComponents.footer).toEqual('footer')
+      expect(res.locals.feComponents.cssIncludes[1]).toEqual('footer.css')
+      expect(res.locals.feComponents.jsIncludes[1]).toEqual('footer.js')
+    })
+  })
+
+  describe('When fallback is requested', () => {
+    it('must not call getComponents()', async () => {
+      // Given
+      const middleware = getFrontendComponents({ pdsUrl: '', useFallbacksByDefault: true })
+      const req = {} as Request
+      const res = createResponseObject('hgjgjhgjhg')
+      jest.spyOn(ComponentApiClientModule, 'getComponents')
+
+      // When
+      await middleware(req, res, jest.fn() as NextFunction)
+
+      // Then
+      expect(ComponentApiClientModule.getComponents).not.toHaveBeenCalled()
+    })
+
+    it('return the content of the header fallback component', async () => {
+      // Given
+      const middleware = getFrontendComponents({ pdsUrl: '', useFallbacksByDefault: true })
+      const req = {} as Request
+      const res = createResponseObject('hgjgjhgjhg')
+      jest.spyOn(ComponentApiClientModule, 'getComponents')
+
+      // When
+      await middleware(req, res, jest.fn() as NextFunction)
+
+      // Then
+      expect(res.locals.feComponents).toBeDefined()
+      expect(res.locals.feComponents.header).toContain('probation-common-fallback-header__link')
+    })
+
+    it('return the content of the footer fallback component', async () => {
+      // Given
+      const middleware = getFrontendComponents({ pdsUrl: '', useFallbacksByDefault: true })
+      const req = {} as Request
+      const res = createResponseObject('hgjgjhgjhg')
+      jest.spyOn(ComponentApiClientModule, 'getComponents')
+
+      // When
+      await middleware(req, res, jest.fn() as NextFunction)
+
+      // Then
+      expect(res.locals.feComponents).toBeDefined()
+      expect(res.locals.feComponents.footer).toContain('probation-common-fallback-footer')
+      expect(res.locals.feComponents.cssIncludes).toHaveLength(0)
+      expect(res.locals.feComponents.jsIncludes).toHaveLength(0)
+    })
+  })
+
+  describe('when no user token is provided', () => {
+    it('must not call getComponents()', async () => {
+      // Given
+      const middleware = getFrontendComponents({ pdsUrl: '' })
+      const req = {} as Request
+      const res = createResponseObjectWithNoUser()
+      jest.spyOn(ComponentApiClientModule, 'getComponents')
+
+      // When
+      await middleware(req, res, jest.fn() as NextFunction)
+
+      // Then
+      expect(ComponentApiClientModule.getComponents).not.toHaveBeenCalled()
+    })
+
+    it('return the content of the header fallback component', async () => {
+      // Given
+      const middleware = getFrontendComponents({ pdsUrl: '' })
+      const req = {} as Request
+      const res = createResponseObjectWithNoUser()
+      jest.spyOn(ComponentApiClientModule, 'getComponents')
+
+      // When
+      await middleware(req, res, jest.fn() as NextFunction)
+
+      // Then
+      expect(res.locals.feComponents).toBeDefined()
+      expect(res.locals.feComponents.header).toContain('probation-common-fallback-header__link')
+    })
+
+    it('return the content of the footer fallback component', async () => {
+      // Given
+      const middleware = getFrontendComponents({ pdsUrl: '' })
+      const req = {} as Request
+      const res = createResponseObjectWithNoUser()
+      jest.spyOn(ComponentApiClientModule, 'getComponents')
+
+      // When
+      await middleware(req, res, jest.fn() as NextFunction)
+
+      // Then
+      expect(res.locals.feComponents).toBeDefined()
+      expect(res.locals.feComponents.footer).toContain('probation-common-fallback-footer')
+      expect(res.locals.feComponents.cssIncludes).toHaveLength(0)
+      expect(res.locals.feComponents.jsIncludes).toHaveLength(0)
+    })
+  })
+
+  describe('When getComponents() call throws', () => {
+    it('return the content of the header fallback component', async () => {
+      // Given
+      const middleware = getFrontendComponents({ pdsUrl: '' })
+      const req = {} as Request
+      const res = createResponseObject('hgjgjhgjhg')
+      jest.spyOn(ComponentApiClientModule, 'getComponents').mockRejectedValue('some sort of exception')
+
+      // When
+      await middleware(req, res, jest.fn() as NextFunction)
+
+      // Then
+      expect(res.locals.feComponents).toBeDefined()
+      expect(res.locals.feComponents.header).toContain('probation-common-fallback-header__link')
+    })
+
+    it('return the content of the footer fallback component', async () => {
+      // Given
+      const middleware = getFrontendComponents({ pdsUrl: '' })
+      const req = {} as Request
+      const res = createResponseObject('hgjgjhgjhg')
+      jest.spyOn(ComponentApiClientModule, 'getComponents').mockRejectedValue('some sort of exception')
+
+      // When
+      await middleware(req, res, jest.fn() as NextFunction)
+
+      // Then
+      expect(res.locals.feComponents).toBeDefined()
+      expect(res.locals.feComponents.footer).toContain('probation-common-fallback-footer')
+      expect(res.locals.feComponents.cssIncludes).toHaveLength(0)
+      expect(res.locals.feComponents.jsIncludes).toHaveLength(0)
+    })
   })
 })

--- a/src/componentsService.test.ts
+++ b/src/componentsService.test.ts
@@ -1,10 +1,10 @@
 import { Request, Response, NextFunction } from 'express'
 import nunjucks from 'nunjucks'
 import { describe } from 'node:test'
-import bunyan from 'bunyan'
 import getFrontendComponents from './componentsService'
 import * as UpdateCspModule from './utils/updateCsp'
 import ComponentApiClientModule from './data/componentApi/componentApiClient'
+import { fakeLogger } from '../test/helpers/loggerStub'
 
 const apiResponse = {
   header: { html: 'header', css: ['header.css'], javascript: ['header.js'] },
@@ -45,10 +45,6 @@ describe('getFrontendComponents', () => {
     return {
       locals: {},
     } as any as Response
-  }
-
-  function fakeLogger() {
-    return { error: jest.fn() } as any as bunyan
   }
 
   const stubUpdateCsp = () => jest.spyOn(UpdateCspModule, 'default').mockImplementation(jest.fn())
@@ -160,9 +156,9 @@ describe('getFrontendComponents', () => {
       expect(res.locals.feComponents.header).toContain('probation-common-fallback-header__link')
     })
 
-    it('returns the expected footer component when classes are added to the header', async () => {
+    it('return the content of the footer fallback component', async () => {
       // Given
-      const middleware = getFrontendComponents({ pdsUrl: '', useFallbacksByDefault: true, classes: 'my-classes' })
+      const middleware = getFrontendComponents({ pdsUrl: '', useFallbacksByDefault: true })
       const req = {} as Request
       const res = createResponseObject('phUw9cruyosubane')
       jest.spyOn(ComponentApiClientModule, 'getComponents')
@@ -177,9 +173,26 @@ describe('getFrontendComponents', () => {
       expect(res.locals.feComponents.jsIncludes).toHaveLength(0)
     })
 
-    it('return the content of the footer fallback component', async () => {
+    it('returns the content of the header fallback component when a user defined class is added', async () => {
       // Given
-      const middleware = getFrontendComponents({ pdsUrl: '', useFallbacksByDefault: true })
+      const middleware = getFrontendComponents({ pdsUrl: '', useFallbacksByDefault: true, classes: 'my-classes' })
+      const req = {} as Request
+      const res = createResponseObject('phUw9cruyosubane')
+      jest.spyOn(ComponentApiClientModule, 'getComponents')
+
+      // When
+      await middleware(req, res, jest.fn() as NextFunction)
+
+      // Then
+      expect(res.locals.feComponents).toBeDefined()
+      expect(res.locals.feComponents.header).toContain('probation-common-fallback-header__link')
+      expect(res.locals.feComponents.header).toContain('my-classes')
+      // expect(res.locals.feComponents.header).toEqual('header')
+    })
+
+    it('returns the content of the footer fallback component when a user defined header class is added', async () => {
+      // Given
+      const middleware = getFrontendComponents({ pdsUrl: '', useFallbacksByDefault: true, classes: 'my-classes' })
       const req = {} as Request
       const res = createResponseObject('phUw9cruyosubane')
       jest.spyOn(ComponentApiClientModule, 'getComponents')

--- a/src/componentsService.test.ts
+++ b/src/componentsService.test.ts
@@ -1,6 +1,7 @@
 import { Request, Response, NextFunction } from 'express'
 import nunjucks from 'nunjucks'
 import { describe } from 'node:test'
+import bunyan from 'bunyan'
 import getFrontendComponents from './componentsService'
 import * as UpdateCspModule from './utils/updateCsp'
 import ComponentApiClientModule from './data/componentApi/componentApiClient'
@@ -44,6 +45,10 @@ describe('getFrontendComponents', () => {
     return {
       locals: {},
     } as any as Response
+  }
+
+  function fakeLogger() {
+    return { error: jest.fn() } as any as bunyan
   }
 
   const stubUpdateCsp = () => jest.spyOn(UpdateCspModule, 'default').mockImplementation(jest.fn())
@@ -241,7 +246,7 @@ describe('getFrontendComponents', () => {
   describe('When getComponents() call throws', () => {
     it('return the content of the header fallback component', async () => {
       // Given
-      const middleware = getFrontendComponents({ pdsUrl: '' })
+      const middleware = getFrontendComponents({ pdsUrl: '', logger: fakeLogger() })
       const req = {} as Request
       const res = createResponseObject('phUw9cruyosubane')
       jest.spyOn(ComponentApiClientModule, 'getComponents').mockRejectedValue('some sort of exception')
@@ -256,7 +261,7 @@ describe('getFrontendComponents', () => {
 
     it('return the content of the footer fallback component', async () => {
       // Given
-      const middleware = getFrontendComponents({ pdsUrl: '' })
+      const middleware = getFrontendComponents({ pdsUrl: '', logger: fakeLogger() })
       const req = {} as Request
       const res = createResponseObject('phUw9cruyosubane')
       jest.spyOn(ComponentApiClientModule, 'getComponents').mockRejectedValue('some sort of exception')

--- a/src/componentsService.ts
+++ b/src/componentsService.ts
@@ -12,7 +12,7 @@ const defaultOptions: Partial<RequestOptions> = {
 }
 
 export default function getFrontendComponents(requestOptions?: RequestOptions): RequestHandler {
-  const { logger, timeoutOptions, useFallbacksByDefault } = {
+  const { logger, timeoutOptions, useFallbacksByDefault, classes } = {
     ...defaultOptions,
     ...requestOptions,
   }
@@ -40,7 +40,12 @@ export default function getFrontendComponents(requestOptions?: RequestOptions): 
     }
 
     try {
-      const { header, footer } = await componentApiClient.getComponents(res.locals.user.token, timeoutOptions, logger)
+      const { header, footer } = await componentApiClient.getComponents({
+        userToken: res.locals.user.token!,
+        timeoutOptions: timeoutOptions!,
+        log: logger!,
+        classes,
+      })
 
       res.locals.feComponents = {
         header: header.html,

--- a/src/data/componentApi/componentApiClient.test.ts
+++ b/src/data/componentApi/componentApiClient.test.ts
@@ -1,0 +1,130 @@
+import type bunyan from 'bunyan'
+
+// const mockGet = jest.fn().mockReturnThis() // Allows chaining after .get()
+const mockSet = jest.fn().mockReturnThis() // Allows chaining after .set()
+const mockQuery = jest.fn().mockReturnThis() // Allows chaining after .query()
+const mockRetry = jest.fn().mockReturnThis() // Allows chaining after .send()
+const mockSend = jest.fn().mockReturnThis() // Allows chaining after .retry()
+const mockTimeout = jest.fn().mockReturnThis() // Allows chaining after .timeout()
+
+jest.mock('superagent', () => {
+  const mockChain = {
+    // get: mockGet, // Allows chaining after .get()
+    set: mockSet, // Allows chaining after .set()
+    query: mockQuery, // Allows chaining after .query()
+    retry: mockRetry, // Allows chaining after .send()
+    send: mockSend, // Allows chaining after .retry()
+    timeout: mockTimeout, // Allows chaining after .timeout()
+    // Make the chain object awaitable by implementing a custom .then()
+    then: jest.fn(resolve => resolve({ body: { id: 42, name: 'Alice' } })),
+  }
+
+  return {
+    get: jest.fn(() => mockChain),
+    post: jest.fn(() => mockChain),
+    put: jest.fn(() => mockChain),
+    retry: jest.fn(() => mockChain),
+    timeout: jest.fn(() => mockChain),
+  }
+})
+
+// needed so that superagent module is mocked up in the Component module
+import ComponentApiClientModule from './componentApiClient' // eslint-disable-line import/first
+
+describe('getComponents', () => {
+  beforeEach(() => {
+    jest.clearAllMocks() // Clear call histories between tests
+  })
+
+  const createLogger = () =>
+    ({
+      info: jest.fn(),
+    }) as bunyan
+
+  const createResponse = async (log: bunyan, userclass?: string) =>
+    ComponentApiClientModule.getComponents({
+      log,
+      timeoutOptions: { response: 2500, deadline: 2500 },
+      userToken: 'userToken',
+      classes: userclass,
+    })
+
+  it('fetches the content of the header and footer', async () => {
+    // Given
+    const logger = createLogger()
+
+    // When
+    await createResponse(logger)
+
+    // Then
+    expect(mockQuery).toHaveBeenCalledWith('component=header&component=footer')
+  })
+
+  it('fetches the content of the header and footer', async () => {
+    // Given
+    const logger = createLogger()
+
+    // When
+    await createResponse(logger, 'my-class')
+
+    // Then
+    expect(mockQuery).toHaveBeenCalledWith('component=header&component=footer&classes=my-class')
+  })
+
+  it('forward the provided user token', async () => {
+    // Given
+    const logger = createLogger()
+
+    // When
+    await createResponse(logger)
+
+    // Then
+    expect(mockSet).toHaveBeenCalledWith({ 'x-user-token': 'userToken' })
+  })
+
+  it('must retry at least once', async () => {
+    // Given
+    const logger = createLogger()
+
+    // When
+    await createResponse(logger)
+
+    // Then
+    const firstRetryArgument = mockRetry.mock.calls[0][0]
+    expect(firstRetryArgument).toEqual(1)
+  })
+
+  // it('request using the configured API URL', async () => {
+  //     // Given
+  //     const logger = createLogger()
+
+  //     // When
+  //     await createResponse(logger)
+
+  //     // Then
+  //     const providedUrl = mockGet.mock.calls
+  //     expect(providedUrl).toEqual('http://fe-components')
+  // })
+
+  it('sets the value of the timeout setting provided', async () => {
+    // Given
+    const logger = createLogger()
+
+    // When
+    await createResponse(logger)
+
+    // Then
+    expect(mockTimeout).toHaveBeenCalledWith({ deadline: 2500, response: 2500 })
+  })
+
+  it('returns the body of the Response', async () => {
+    // Given
+    const logger = createLogger()
+
+    // When
+    const response = await createResponse(logger)
+
+    // Then
+    expect(response).toEqual({ id: 42, name: 'Alice' })
+  })
+})

--- a/src/data/componentApi/componentApiClient.test.ts
+++ b/src/data/componentApi/componentApiClient.test.ts
@@ -29,6 +29,7 @@ jest.mock('superagent', () => {
 })
 
 // needed so that superagent module is mocked up in the Component module
+import superagent from 'superagent' // eslint-disable-line import/first
 import ComponentApiClientModule from './componentApiClient' // eslint-disable-line import/first
 
 describe('getComponents', () => {
@@ -94,17 +95,16 @@ describe('getComponents', () => {
     expect(firstRetryArgument).toEqual(1)
   })
 
-  // it('request using the configured API URL', async () => {
-  //     // Given
-  //     const logger = createLogger()
+  it('request using the configured API URL', async () => {
+    // Given
+    const logger = createLogger()
 
-  //     // When
-  //     await createResponse(logger)
+    // When
+    await createResponse(logger)
 
-  //     // Then
-  //     const providedUrl = mockGet.mock.calls
-  //     expect(providedUrl).toEqual('http://fe-components')
-  // })
+    // Then
+    expect(superagent.get).toHaveBeenCalledWith('http://fe-components/api/components')
+  })
 
   it('sets the value of the timeout setting provided', async () => {
     // Given

--- a/src/data/componentApi/componentApiClient.ts
+++ b/src/data/componentApi/componentApiClient.ts
@@ -7,21 +7,24 @@ import TimeoutOptions from '../../types/TimeoutOptions'
 
 export type ComponentsApiResponse<T extends AvailableComponent[]> = Record<T[number], Component>
 
+export type GetComponentsArg = {
+  userToken: string
+  timeoutOptions: TimeoutOptions
+  log: bunyan | typeof console
+  classes?: string
+}
+
 export default {
-  async getComponents<T extends AvailableComponent[]>(
-    userToken: string,
-    timeoutOptions: TimeoutOptions,
-    log: bunyan | typeof console,
-  ): Promise<ComponentsApiResponse<T>> {
+  async getComponents<T extends AvailableComponent[]>(param: GetComponentsArg): Promise<ComponentsApiResponse<T>> {
     const result = await superagent
       .get(`${config.apis.feComponents.url}/api/components`)
       .retry(1, (err, _res) => {
-        if (err) log.info(`Retry handler found API error with ${err.code} ${err.message}`)
+        if (err) param.log.info(`Retry handler found API error with ${err.code} ${err.message}`)
         return undefined // retry handler only for logging retries, not to influence retry logic
       })
       .query('component=header&component=footer')
-      .set({ 'x-user-token': userToken })
-      .timeout(timeoutOptions)
+      .set({ 'x-user-token': param.userToken })
+      .timeout(param.timeoutOptions)
 
     return result.body
   },

--- a/src/data/componentApi/componentApiClient.ts
+++ b/src/data/componentApi/componentApiClient.ts
@@ -14,6 +14,12 @@ export type GetComponentsArg = {
   classes?: string
 }
 
+function generateQueryParams(param: GetComponentsArg): string | Record<string, any> {
+  return param.classes
+    ? `component=header&component=footer&classes=${param.classes}`
+    : 'component=header&component=footer'
+}
+
 export default {
   async getComponents<T extends AvailableComponent[]>(param: GetComponentsArg): Promise<ComponentsApiResponse<T>> {
     const result = await superagent
@@ -22,7 +28,7 @@ export default {
         if (err) param.log.info(`Retry handler found API error with ${err.code} ${err.message}`)
         return undefined // retry handler only for logging retries, not to influence retry logic
       })
-      .query('component=header&component=footer')
+      .query(generateQueryParams(param))
       .set({ 'x-user-token': param.userToken })
       .timeout(param.timeoutOptions)
 

--- a/src/types/RequestOptions.ts
+++ b/src/types/RequestOptions.ts
@@ -7,4 +7,5 @@ export default interface RequestOptions {
   logger?: bunyan | typeof console
   useFallbacksByDefault?: boolean
   timeoutOptions?: TimeoutOptions
+  classes?: string
 }

--- a/src/utils/fallbacks.ts
+++ b/src/utils/fallbacks.ts
@@ -10,6 +10,7 @@ export function getFallbackHeader(user: HmppsUser | null, requestOptions: Reques
     environmentName,
     user,
     name: initialiseName(user?.displayName),
+    classes: requestOptions.classes,
   })
 }
 

--- a/test/helpers/loggerStub.ts
+++ b/test/helpers/loggerStub.ts
@@ -1,0 +1,5 @@
+import bunyan from 'bunyan'
+
+export function fakeLogger() {
+  return { error: jest.fn() } as any as bunyan
+}


### PR DESCRIPTION
### Description of the change

This pull request updates our global Nunjucks header template macro to accept and render custom CSS classes dynamically via a new `params.classes` option. 

Some underlying micro-services want to be able to add unique classes directly to the primary `<header>` container. This allows them to identify exactly what underlying service is reached, tag specific pages for analytics tracking, or apply contextual micro-frontend overrides.

**How it works:**
* We expanded the header macro schema to accept `params.classes`.
* We updated the template HTML markup to cleanly concatenate these incoming strings alongside our baseline framework classes using standard Nunjucks template conditionals:

```njk
<header class="app-header{% if params.classes %} {{ params.classes }}{% endif %}" data-module="app-header">
  <div class="app-header__container">
    {# Core layout elements #}
  </div>
</header>
```


### Possible drawbacks

* **Class pollution & collisions**: If an underlying service passes a class string containing style rules that conflict with core design architecture layouts, it could unintentionally skew or break the layout grid. 


### Verification process

#### How did you verify that all new functionality works as expected?
* **Action**: Ran the component locally and modified a service page to pass a custom identifier string directly to the macro:
  ```njk
  {{ appHeader({
    classes: "service-identifier-tax-credits service-theme-blue"
  }) }}
  ```

#### How did you verify that all changed functionality works as expected?
* **Action**: Checked local service pages where the parameter is omitted.


* **Observation**: All baseline layout, accessibility, snapshot matching, and schema integration assertions passed without warning flags or functional issues.


### Release notes

Added a `classes` parameter to the header macro component to support micro-service identifier strings and custom configurations.
